### PR TITLE
Add unit tests, fix bug in startup routine

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,6 +15,7 @@ def addStages() {
       },
       junit: {
         sh './gradlew test'
+        junit 'build/test-results/**/*.xml'
       },
     )
   }

--- a/README.md
+++ b/README.md
@@ -24,9 +24,7 @@ the node.
 
 The library also makes sure that the container is fully started and ready to communicate
 with before executing the closure body. To do this, it calls `pg_isready` until it
-succeeds. Although it catches and suppresses errors from the failed calls while the
-container is starting, you may see some red X's in Blue Ocean's output. They can be safely
-ignored.
+succeeds.
 
 
 [jenkins-shared-lib-usage]: https://jenkins.io/doc/book/pipeline/shared-libraries/#using-libraries

--- a/build.gradle
+++ b/build.gradle
@@ -2,9 +2,13 @@ apply plugin: 'groovy'
 
 repositories {
   mavenCentral()
+  maven {
+    url 'https://jitpack.io'
+  }
 }
 
 dependencies {
+  compile 'com.github.AbletonDevTools:jenkins-pipeline-mocks:0.4.0'
   compile 'org.codehaus.groovy:groovy-all:2.4.10'
 
   testCompile 'junit:junit:4.12'

--- a/test/postgresTest.groovy
+++ b/test/postgresTest.groovy
@@ -1,0 +1,15 @@
+import com.lesfurets.jenkins.unit.BasePipelineTest
+import org.junit.Before
+
+
+@SuppressWarnings('ClassName')
+class postgresTest extends BasePipelineTest {
+  def postgres
+
+  @Override
+  @Before
+  void setUp() {
+    super.setUp()
+    this.postgres = new postgres()
+  }
+}

--- a/test/postgresTest.groovy
+++ b/test/postgresTest.groovy
@@ -1,5 +1,14 @@
+import static org.junit.Assert.assertEquals
+import static org.junit.Assert.assertFalse
+import static org.junit.Assert.assertNotNull
+import static org.junit.Assert.assertNull
+import static org.junit.Assert.assertTrue
+
+import com.ableton.DockerMock
+import com.ableton.JenkinsMocks
 import com.lesfurets.jenkins.unit.BasePipelineTest
 import org.junit.Before
+import org.junit.Test
 
 
 @SuppressWarnings('ClassName')
@@ -11,5 +20,62 @@ class postgresTest extends BasePipelineTest {
   void setUp() {
     super.setUp()
     this.postgres = new postgres()
+
+    postgres.with {
+      docker = new DockerMock()
+      env = [
+        BUILD_ID: '1',
+        JOB_BASE_NAME: 'TestJob',
+      ]
+
+      error = JenkinsMocks.error
+      pwd = JenkinsMocks.pwd
+      sh = JenkinsMocks.sh
+      writeFile = {}
+    }
+  }
+
+  @Test
+  void withDb() throws Exception {
+    def dataDir = JenkinsMocks.pwd(temp: true) + '/1/postgres/data'
+    JenkinsMocks.addShMock('id -u', '1000', 0)
+    JenkinsMocks.addShMock("mkdir ${dataDir}", '', 0)
+    JenkinsMocks.addShMock("pg_isready -h \$DB_PORT_5432_TCP_ADDR", '', 0)
+
+    def bodyExecuted = false
+    def bodyResult = postgres.withDb('testdb', '9.6') {
+      bodyExecuted = true
+      return 123
+    }
+
+    assertTrue(bodyExecuted)
+    assertEquals(123, bodyResult)
+  }
+
+  @Test
+  void withDbContainerFail() throws Exception {
+    def dataDir = JenkinsMocks.pwd(temp: true) + '/1/postgres/data'
+    JenkinsMocks.addShMock('id -u', '1000', 0)
+    JenkinsMocks.addShMock("mkdir ${dataDir}", '', 0)
+    JenkinsMocks.addShMock("pg_isready -h \$DB_PORT_5432_TCP_ADDR", '', 1)
+
+    def bodyExecuted = false
+    def bodyResult = null
+    def exceptionThrown = false
+    try {
+      bodyResult = postgres.withDb('testdb', '9.6') {
+        bodyExecuted = true
+        return 123
+      }
+    } catch (error) {
+      exceptionThrown = true
+      assertNotNull(error)
+    }
+
+    // The current implementation of postgres.withDb() has a bug where it does not throw
+    // an exception if the container fails to start.
+    // assertTrue(exceptionThrown)
+    // assertFalse(bodyExecuted)
+    // assertNull(bodyResult)
   }
 }

--- a/test/postgresTest.groovy
+++ b/test/postgresTest.groovy
@@ -30,6 +30,7 @@ class postgresTest extends BasePipelineTest {
 
       error = JenkinsMocks.error
       pwd = JenkinsMocks.pwd
+      retry = JenkinsMocks.retry
       sh = JenkinsMocks.sh
       writeFile = {}
     }
@@ -72,10 +73,8 @@ class postgresTest extends BasePipelineTest {
       assertNotNull(error)
     }
 
-    // The current implementation of postgres.withDb() has a bug where it does not throw
-    // an exception if the container fails to start.
-    // assertTrue(exceptionThrown)
-    // assertFalse(bodyExecuted)
-    // assertNull(bodyResult)
+    assertTrue(exceptionThrown)
+    assertFalse(bodyExecuted)
+    assertNull(bodyResult)
   }
 }

--- a/vars/postgres.groovy
+++ b/vars/postgres.groovy
@@ -37,16 +37,9 @@ def withDb(String dbName, String postgresVersion, body) {
     // build node. Note that when using docker.image.inside(), the closure body is run
     // instead of the entrypoint script.
     postgresImage.inside("--link ${c.id}:db") {
-      retries = 30
-      while (retries > 0) {
-        try {
-          sh "pg_isready -h \$DB_PORT_5432_TCP_ADDR"
-          break
-        }
-        catch (error) {
-          sleep 1
-          retries--
-        }
+      retry(30) {
+        sleep 1
+        sh "pg_isready -h \$DB_PORT_5432_TCP_ADDR"
       }
     }
 


### PR DESCRIPTION
This PR adds unit tests to this project, and also fixes a bug in the startup routine of `postgres.withDB`. The previous implementation used a try/catch block but never threw if the connection failed to be established. Using a `retry` loop fixes this, and also is generally a much more elegant solution (I didn't know about `retry` when I wrote this library originally 😅 ).

ptal @AbletonDevTools/gotham-city, thanks!