### PR TITLE
Make postgres.withDb safe to call from multiple parallel branches

### DIFF
--- a/src/com/ableton/PostgresDocker.groovy
+++ b/src/com/ableton/PostgresDocker.groovy
@@ -41,10 +41,9 @@ class PostgresDocker implements Serializable {
       // container runs into all sorts of weird problems during initialization.
       // Also, while we're at it, we can define the POSTGRES_DB environment variable which
       // will instruct the container to create a database for us with the given name.
-      String dockerfile = "${tempDir}/Dockerfile"
       String uid = this.uid ?: script.sh(returnStdout: true, script: 'id -u').trim()
       script.writeFile(
-        file: dockerfile,
+        file: 'Dockerfile',
         text: """
         FROM postgres:${version}
         RUN useradd --uid ${uid} --user-group ${postgresUser}
@@ -59,12 +58,12 @@ class PostgresDocker implements Serializable {
       String imageName = script.env.JOB_BASE_NAME.toLowerCase()
       @SuppressWarnings('VariableTypeRequired')
       def postgresImage =
-        script.docker.build("${imageName}:${script.env.BUILD_ID}", "-f ${dockerfile} .")
+        script.docker.build("${imageName}:${script.env.BUILD_ID}", '-f Dockerfile .')
 
       // Start the newly built container. The postgres data dir must be mapped to our
       // temporary data directory or else initdb runs into permission problems when trying
       // to chmod the data dir to our custom UID.
-      script.dir("${tempDir}/data") {
+      script.dir('data') {
         String dockerArgs = "-p ${port}:5432 -v ${script.pwd()}:/var/lib/postgresql/data"
         postgresImage.withRun(dockerArgs) { c ->
           // Wait for the database to come up, for up to 30 seconds. Note that this command

--- a/src/com/ableton/PostgresDocker.groovy
+++ b/src/com/ableton/PostgresDocker.groovy
@@ -24,6 +24,13 @@ class PostgresDocker implements Serializable {
    */
   String version = 'latest'
 
+  /**
+   * Seed for random number generator. Dy default, a unique seed will be used based on the
+   * current time and the object's hashCode. Normally you shouldn't need to touch this
+   * field.
+   */
+  protected long randomSeed = System.currentTimeMillis() * this.hashCode()
+
   @SuppressWarnings('MethodReturnTypeRequired')
   def withDb(String dbName, Closure body) {
     assert script
@@ -88,5 +95,23 @@ class PostgresDocker implements Serializable {
       script.deleteDir()
       return bodyResult
     }
+  }
+
+  /**
+   * Generates a string of random digits
+   * @param length Number of characters to produce
+   * @param seed Random seed (defaults to system time in milliseconds)
+   */
+  protected static String getRandomDigitString(int length, long seed) {
+    if (length <= 0) {
+      throw new IllegalArgumentException('Invalid string length')
+    }
+    String pool = '0123456789'
+    @SuppressWarnings('InsecureRandom')
+    Random random = new Random(seed)
+    List randomChars = (0..length - 1).collect {
+      pool[random.nextInt(pool.size())]
+    }
+    return randomChars.join('')
   }
 }

--- a/src/com/ableton/PostgresDocker.groovy
+++ b/src/com/ableton/PostgresDocker.groovy
@@ -36,11 +36,11 @@ class PostgresDocker implements Serializable {
     String pwd = script.pwd()
     String tempDir = script.pwd(tmp: true) + "/${script.env.BUILD_ID}/postgres"
     script.dir(tempDir) {
-      // Here we create a Dockerfile based on the postgres version, but with a user mapping
-      // that corresponds to the UID on the local machine. Without this, the postgres
-      // container runs into all sorts of weird problems during initialization.
-      // Also, while we're at it, we can define the POSTGRES_DB environment variable which
-      // will instruct the container to create a database for us with the given name.
+      // Here we create a Dockerfile based on the postgres version, but with a custom UID
+      // mapping. Without this, the postgres container runs into all sorts of weird
+      // problems during initialization. Also, while we're at it, we can define the
+      // POSTGRES_DB environment variable which will instruct the container to create
+      // a database for us with the given name.
       String uid = this.uid ?: script.sh(returnStdout: true, script: 'id -u').trim()
       script.writeFile(
         file: 'Dockerfile',
@@ -66,7 +66,7 @@ class PostgresDocker implements Serializable {
       script.dir('data') {
         String dockerArgs = "-p ${port}:5432 -v ${script.pwd()}:/var/lib/postgresql/data"
         postgresImage.withRun(dockerArgs) { c ->
-          // Wait for the database to come up, for up to 30 seconds. Note that this command
+          // Wait for the database to come up for up to 30 seconds. Note that this command
           // is run from inside a new instance of the postgres container and linked to the
           // database container. By doing this, the postgres client does not need to be
           // installed on the build node. Note that when using docker.image.inside(), the

--- a/src/com/ableton/PostgresDocker.groovy
+++ b/src/com/ableton/PostgresDocker.groovy
@@ -41,7 +41,8 @@ class PostgresDocker implements Serializable {
 
     // Get the current directory so that the closure body is executed in the right place
     String pwd = script.pwd()
-    String tempDir = script.pwd(tmp: true) + "/${script.env.BUILD_ID}/postgres"
+    String tempDir = script.pwd(tmp: true) + "/${script.env.BUILD_ID}/postgres-" +
+      getRandomDigitString(8, randomSeed)
     script.dir(tempDir) {
       // Here we create a Dockerfile based on the postgres version, but with a custom UID
       // mapping. Without this, the postgres container runs into all sorts of weird

--- a/src/com/ableton/PostgresDocker.groovy
+++ b/src/com/ableton/PostgresDocker.groovy
@@ -31,56 +31,61 @@ class PostgresDocker implements Serializable {
 
     @SuppressWarnings('VariableTypeRequired')
     def bodyResult = null
+
+    // Get the current directory so that the closure body is executed in the right place
+    String pwd = script.pwd()
     String tempDir = script.pwd(tmp: true) + "/${script.env.BUILD_ID}/postgres"
+    script.dir(tempDir) {
+      // Here we create a Dockerfile based on the postgres version, but with a user mapping
+      // that corresponds to the UID on the local machine. Without this, the postgres
+      // container runs into all sorts of weird problems during initialization.
+      // Also, while we're at it, we can define the POSTGRES_DB environment variable which
+      // will instruct the container to create a database for us with the given name.
+      String dockerfile = "${tempDir}/Dockerfile"
+      String uid = this.uid ?: script.sh(returnStdout: true, script: 'id -u').trim()
+      script.writeFile(
+        file: dockerfile,
+        text: """
+        FROM postgres:${version}
+        RUN useradd --uid ${uid} --user-group ${postgresUser}
+        ENV POSTGRES_USER=${postgresUser}
+        ENV POSTGRES_DB=${dbName}
+        USER ${postgresUser}
+        EXPOSE 5432
+        ENTRYPOINT ["/docker-entrypoint.sh", "postgres"]
+      """
+      )
 
-    // Here we create a Dockerfile based on the postgres version, but with a user mapping
-    // that corresponds to the UID on the local machine. Without this, the postgres
-    // container runs into all sorts of weird problems during initialization.
-    // Also, while we're at it, we can define the POSTGRES_DB environment variable which
-    // will instruct the container to create a database for us with the given name.
-    String dockerfile = "${tempDir}/Dockerfile"
-    String uid = this.uid ?: script.sh(returnStdout: true, script: 'id -u').trim()
-    script.writeFile(
-      file: dockerfile,
-      text: """
-      FROM postgres:${version}
-      RUN useradd --uid ${uid} --user-group ${postgresUser}
-      ENV POSTGRES_USER=${postgresUser}
-      ENV POSTGRES_DB=${dbName}
-      USER ${postgresUser}
-      EXPOSE 5432
-      ENTRYPOINT ["/docker-entrypoint.sh", "postgres"]
-    """
-    )
+      String imageName = script.env.JOB_BASE_NAME.toLowerCase()
+      @SuppressWarnings('VariableTypeRequired')
+      def postgresImage =
+        script.docker.build("${imageName}:${script.env.BUILD_ID}", "-f ${dockerfile} .")
 
-    String imageName = script.env.JOB_BASE_NAME.toLowerCase()
-    @SuppressWarnings('VariableTypeRequired')
-    def postgresImage =
-      script.docker.build("${imageName}:${script.env.BUILD_ID}", "-f ${dockerfile} .")
+      // Start the newly built container. The postgres data dir must be mapped to our
+      // temporary data directory or else initdb runs into permission problems when trying
+      // to chmod the data dir to our custom UID.
+      script.dir("${tempDir}/data") {
+        String dockerArgs = "-p ${port}:5432 -v ${script.pwd()}:/var/lib/postgresql/data"
+        postgresImage.withRun(dockerArgs) { c ->
+          // Wait for the database to come up, for up to 30 seconds. Note that this command
+          // is run from inside a new instance of the postgres container and linked to the
+          // database container. By doing this, the postgres client does not need to be
+          // installed on the build node. Note that when using docker.image.inside(), the
+          // closure body is run instead of the entrypoint script.
+          postgresImage.inside("--link ${c.id}:db") {
+            script.retry(30) {
+              script.sleep 1
+              script.sh "pg_isready -h \$DB_PORT_5432_TCP_ADDR"
+            }
+          }
 
-    // Start the newly built container. The postgres data dir must be mapped to our
-    // temporary data directory or else initdb runs into permission problems when trying
-    // to chmod the data dir to our custom UID.
-    script.dir("${tempDir}/data") {
-      String dockerArgs = "-p ${port}:5432 -v ${script.pwd()}:/var/lib/postgresql/data"
-      postgresImage.withRun(dockerArgs) { c ->
-        // Wait for the database to come up, for up to 30 seconds. Note that this command
-        // is run from inside a new instance of the postgres container and linked to the
-        // database container. By doing this, the postgres client does not need to be
-        // installed on the build node. Note that when using docker.image.inside(), the
-        // closure body is run instead of the entrypoint script.
-        postgresImage.inside("--link ${c.id}:db") {
-          script.retry(30) {
-            script.sleep 1
-            script.sh "pg_isready -h \$DB_PORT_5432_TCP_ADDR"
+          // Now the database should be up and running, so we can execute the body from
+          // outside the container.
+          script.dir(pwd) {
+            bodyResult = body.call()
           }
         }
-
-        // Now the database should be up and running, so we can execute the body from
-        // outside the container.
-        bodyResult = body.call()
       }
-
       script.deleteDir()
       return bodyResult
     }

--- a/test/com/ableton/PostgresDockerTest.groovy
+++ b/test/com/ableton/PostgresDockerTest.groovy
@@ -1,6 +1,7 @@
 package com.ableton
 
 import static org.junit.Assert.assertEquals
+import static org.junit.Assert.assertNotEquals
 import static org.junit.Assert.assertNotNull
 import static org.junit.Assert.assertTrue
 
@@ -105,5 +106,28 @@ class PostgresDockerTest extends BasePipelineTest {
 
     PostgresDocker postgres = new PostgresDocker(script: script, uid: 123)
     postgres.withDb('testdb') {}
+  }
+
+  @Test
+  void getRandomDigitString() throws Exception {
+    assertEquals('0897531194', PostgresDocker.getRandomDigitString(10, 0))
+  }
+
+  @Test
+  void getRandomDigitStringIsRandom() throws Exception {
+    // Ensure that allocating two objects in rapid succession will yield two different
+    // random number generators. Naively seeding the random number generator with
+    // System.currentTimeMillis() would not guarantee this to be the case.
+    PostgresDocker pd1 = new PostgresDocker(script: script)
+    PostgresDocker pd2 = new PostgresDocker(script: script)
+    assertNotEquals(
+      pd1.getRandomDigitString(4, pd1.randomSeed),
+      pd2.getRandomDigitString(4, pd2.randomSeed)
+    )
+  }
+
+  @Test(expected = IllegalArgumentException)
+  void getRandomDigitStringInvalidLength() throws Exception {
+    PostgresDocker.getRandomDigitString(0, 0)
   }
 }

--- a/test/com/ableton/PostgresDockerTest.groovy
+++ b/test/com/ableton/PostgresDockerTest.groovy
@@ -95,7 +95,26 @@ class PostgresDockerTest extends BasePipelineTest {
     JenkinsMocks.addShMock("pg_isready -h \$DB_PORT_5432_TCP_ADDR", '', 0)
 
     PostgresDocker postgres = new PostgresDocker(script: script, port: 1234)
-    postgres.withDb('testdb') {}
+    postgres.withDb('testdb') { port ->
+      assertEquals('1234', port)
+    }
+  }
+
+  @Test
+  void withDbRandomPort() throws Exception {
+    // Expected output given a seed of 1
+    String expectedPort = '15873'
+    JenkinsMocks.addShMock('id -u', '1000', 0)
+    JenkinsMocks.addShMock("pg_isready -h \$DB_PORT_5432_TCP_ADDR", '', 0)
+
+    PostgresDocker postgres = new PostgresDocker(
+      script: script,
+      port: null,
+      randomSeed: 1,
+    )
+    postgres.withDb('testdb') { port ->
+      assertEquals(expectedPort, port)
+    }
   }
 
   @Test

--- a/test/com/ableton/PostgresDockerTest.groovy
+++ b/test/com/ableton/PostgresDockerTest.groovy
@@ -75,4 +75,35 @@ class PostgresDockerTest extends BasePipelineTest {
     PostgresDocker postgres = new PostgresDocker(script: script)
     postgres.withDb('testdb') {}
   }
+
+  @Test(expected = AssertionError)
+  void withDbNoScript() throws Exception {
+    PostgresDocker postgres = new PostgresDocker()
+    postgres.withDb('testdb') {}
+  }
+
+  @Test(expected = AssertionError)
+  void withDbNoDbName() throws Exception {
+    PostgresDocker postgres = new PostgresDocker(script: script)
+    postgres.withDb('') {}
+  }
+
+  @Test
+  void withDbCustomPort() throws Exception {
+    JenkinsMocks.addShMock('id -u', '1000', 0)
+    JenkinsMocks.addShMock("pg_isready -h \$DB_PORT_5432_TCP_ADDR", '', 0)
+
+    PostgresDocker postgres = new PostgresDocker(script: script, port: 1234)
+    postgres.withDb('testdb') {}
+  }
+
+  @Test
+  void withDbCustomUid() throws Exception {
+    // Add a mock for `id -u` that would fail if invoked
+    JenkinsMocks.addShMock('id -u', null, 1)
+    JenkinsMocks.addShMock("pg_isready -h \$DB_PORT_5432_TCP_ADDR", '', 0)
+
+    PostgresDocker postgres = new PostgresDocker(script: script, uid: 123)
+    postgres.withDb('testdb') {}
+  }
 }


### PR DESCRIPTION
This PR uses a unique temporary directory, and also allows the caller to use a random port number instead of the usual `5432`. These two fixes allow `postgres.withDb` to be called from multiple parallel branches without stepping on each other's toes.

Fixes https://github.com/AbletonAppDev/devtools/issues/922, ptal @AbletonDevTools/gotham-city, thanks!